### PR TITLE
Add environment variables to set custom mysql host & user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ MAINTAINER Dirk Steinkopf "https://github.com/dsteinkopf"
 ENV BACKUP_INTERVAL=86400 \
     BACKUP_FIRSTDELAY=0 \
     MYSQLDUMP_ADD_OPTS= \
-    MYSQL_CONNECTION_PARAMS=
+    MYSQL_CONNECTION_PARAMS= \
+    MYSQL_HOST=mysql \
+    MYSQL_USER=root
 
 # Update
 RUN apt-get update && \

--- a/loop.sh
+++ b/loop.sh
@@ -12,7 +12,7 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        MYSQL_CONNECTION_PARAMS="--host=mysql --user=root --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD"
+        MYSQL_CONNECTION_PARAMS="--host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD"
     fi
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS
 


### PR DESCRIPTION
Added MYSQL_HOST and MYSQL_USER to let users set a custom host name and user for their mysql databases.

Their default value is added to the Dockerfile

This change will be useful to me as I am currently trying things with docker networks