### PR TITLE
remove warning about locking system database "mysql"

### DIFF
--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -122,6 +122,7 @@ do
 	# um fuer einen import auf das richtige char-set zu stellen
         #/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables >$TMPFILE 2>&1 || \
 	# CON-catenieren!
+        echo "start backup of $db.$tables" 
         echo "SET NAMES 'utf8';" > $TMPFILE
         /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
@@ -136,7 +137,8 @@ if [ $TOTAL -eq 1 ]; then
 	# alt MKU 2007-12-04
         # /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases >$TMPFILE 2>&1 || \
 	# neu
-	echo "SET NAMES 'utf8';" > $TMPFILE
+        echo "start backup of all databases" 
+	   echo "SET NAMES 'utf8';" > $TMPFILE
         /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases  2>$ERRORFILE >>$TMPFILE || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
 	    #cat $ERRORFILE  | mail -s "Error from $0: DB backup of ALL failed" $ERROREMAILTO

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -48,7 +48,7 @@ trap aterror EXIT # unset below on normal script end
 # 2. alles bis aus --extended-insert (fuer zeilenweiseinserts) wieder einschalten
 #  somit ergibt sich:
 
-MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --quick --default-character-set=utf8 --routines"
+MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --lock-tables --quick --default-character-set=utf8 --routines --hex-blob"
 if [ ! -z "$MYSQL_CONNECTION_PARAMS" ] ; then
     MYSQLOPTS="$MYSQLOPTS $MYSQLDUMP_ADD_OPTS"
 fi
@@ -122,17 +122,9 @@ do
 	# um fuer einen import auf das richtige char-set zu stellen
         #/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables >$TMPFILE 2>&1 || \
 	# CON-catenieren!
-   
-   #the database named "mysql" can't be locked
-   # mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
-    CURRENT_OPTS="$MYSQLOPTS"
-    if [ "$db" != "mysql" ] ; then
-        CURRENT_OPTS="$CURRENT_OPTS --lock-tables";
-    fi 
-
-        echo "start backup of $db" 
+        echo "start backup of $db.$tables" 
         echo "SET NAMES 'utf8';" > $TMPFILE
-        /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $CURRENT_OPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
+        /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
 	    # cat $ERRORFILE  | mail -s "Error from $0: DB backup of $db failed" $ERROREMAILTO
         nice bzip2 -c -9 < $TMPFILE > $DBDUMPSDIR/mysqldump_$db.sql.bz2
@@ -145,8 +137,8 @@ if [ $TOTAL -eq 1 ]; then
 	# alt MKU 2007-12-04
         # /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases >$TMPFILE 2>&1 || \
 	# neu
-        echo "start backup of all databases" 
-	    echo "SET NAMES 'utf8';" > $TMPFILE
+    echo "start backup of all databases" 
+    echo "SET NAMES 'utf8';" > $TMPFILE
         /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases  2>$ERRORFILE >>$TMPFILE || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
 	    #cat $ERRORFILE  | mail -s "Error from $0: DB backup of ALL failed" $ERROREMAILTO

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -48,7 +48,7 @@ trap aterror EXIT # unset below on normal script end
 # 2. alles bis aus --extended-insert (fuer zeilenweiseinserts) wieder einschalten
 #  somit ergibt sich:
 
-MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --lock-tables --quick --default-character-set=utf8 --routines"
+MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --quick --default-character-set=utf8 --routines"
 if [ ! -z "$MYSQL_CONNECTION_PARAMS" ] ; then
     MYSQLOPTS="$MYSQLOPTS $MYSQLDUMP_ADD_OPTS"
 fi
@@ -122,9 +122,17 @@ do
 	# um fuer einen import auf das richtige char-set zu stellen
         #/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables >$TMPFILE 2>&1 || \
 	# CON-catenieren!
-        echo "start backup of $db.$tables" 
+   
+   #the database named "mysql" can't be locked
+   # mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
+    CURRENT_OPTS = "$MYSQLOPTS"
+    if[ "$db" -ne "mysql" ]then:
+        CURRENT_OPTS = "$CURRENT_OPTS --lock-tables";
+    fi 
+
+        echo "start backup of $db" 
         echo "SET NAMES 'utf8';" > $TMPFILE
-        /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
+        /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $CURRENT_OPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
 	    # cat $ERRORFILE  | mail -s "Error from $0: DB backup of $db failed" $ERROREMAILTO
         nice bzip2 -c -9 < $TMPFILE > $DBDUMPSDIR/mysqldump_$db.sql.bz2

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -125,8 +125,8 @@ do
         echo "start backup of $db.$tables" 
         echo "SET NAMES 'utf8';" > $TMPFILE
         /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
-	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
-	    # cat $ERRORFILE  | mail -s "Error from $0: DB backup of $db failed" $ERROREMAILTO
+	cat $ERRORFILE | tee --append $ERRORFILELASTRUN
+	# cat $ERRORFILE  | mail -s "Error from $0: DB backup of $db failed" $ERROREMAILTO
         nice bzip2 -c -9 < $TMPFILE > $DBDUMPSDIR/mysqldump_$db.sql.bz2
 done
 
@@ -137,8 +137,8 @@ if [ $TOTAL -eq 1 ]; then
 	# alt MKU 2007-12-04
         # /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases >$TMPFILE 2>&1 || \
 	# neu
-    echo "start backup of all databases" 
-    echo "SET NAMES 'utf8';" > $TMPFILE
+	echo "start backup of all databases" 
+	echo "SET NAMES 'utf8';" > $TMPFILE
         /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases  2>$ERRORFILE >>$TMPFILE || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
 	    #cat $ERRORFILE  | mail -s "Error from $0: DB backup of ALL failed" $ERROREMAILTO

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -125,9 +125,9 @@ do
    
    #the database named "mysql" can't be locked
    # mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
-    CURRENT_OPTS = "$MYSQLOPTS"
+    CURRENT_OPTS="$MYSQLOPTS"
     if [ "$db" -ne "mysql" ] ; then
-        CURRENT_OPTS = "$CURRENT_OPTS --lock-tables";
+        CURRENT_OPTS="$CURRENT_OPTS --lock-tables";
     fi 
 
         echo "start backup of $db" 

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -48,7 +48,7 @@ trap aterror EXIT # unset below on normal script end
 # 2. alles bis aus --extended-insert (fuer zeilenweiseinserts) wieder einschalten
 #  somit ergibt sich:
 
-MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --lock-tables --quick --default-character-set=utf8 --routines --hex-blob"
+MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --lock-tables --quick --default-character-set=utf8 --routines"
 if [ ! -z "$MYSQL_CONNECTION_PARAMS" ] ; then
     MYSQLOPTS="$MYSQLOPTS $MYSQLDUMP_ADD_OPTS"
 fi

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -126,7 +126,7 @@ do
    #the database named "mysql" can't be locked
    # mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
     CURRENT_OPTS="$MYSQLOPTS"
-    if [ "$db" -ne "mysql" ] ; then
+    if [ "$db" != "mysql" ] ; then
         CURRENT_OPTS="$CURRENT_OPTS --lock-tables";
     fi 
 

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -2,12 +2,12 @@
 #
 # in /root/.my.cnf muss stehen:
 #
-#       [mysqldump]
-#       password = ********
+#   [mysqldump]
+#   password = ********
 #
 # ODER: die connection-Parameter werden übergeben (beachte das fehlende "=" bei subdir):
 #
-#       backup-all-mysql.sh --subdir myhost --host=myhost --user=root --password=abcdef 
+#   backup-all-mysql.sh --subdir myhost --host=myhost --user=root --password=abcdef 
 
 #
 # Effizient importieren kann man dann mit
@@ -31,8 +31,8 @@ ERRORFILE=/tmp/mysql_backup_error.$$
 
 
 function aterror() {
-        rm -f "$TMPFILE"
-        echo >>$ERRORFILELASTRUN "$(date): $0 aborted."
+    rm -f "$TMPFILE"
+    echo >>$ERRORFILELASTRUN "$(date): $0 aborted."
 }
 trap aterror EXIT # unset below on normal script end
 
@@ -48,7 +48,7 @@ trap aterror EXIT # unset below on normal script end
 # 2. alles bis aus --extended-insert (fuer zeilenweiseinserts) wieder einschalten
 #  somit ergibt sich:
 
-MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --lock-tables --quick --default-character-set=utf8 --routines"
+MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --quick --default-character-set=utf8 --routines"
 if [ ! -z "$MYSQL_CONNECTION_PARAMS" ] ; then
     MYSQLOPTS="$MYSQLOPTS $MYSQLDUMP_ADD_OPTS"
 fi
@@ -64,32 +64,32 @@ fi
 
 
 if [ _$1 = _--total ]; then
-        TOTAL=1
-        shift
+    TOTAL=1
+    shift
 else
-        TOTAL=0
+    TOTAL=0
 fi
 
 if [ _$1 = _--subdir ]; then
-        DBDUMPSDIR="$DBDUMPSDIR/$2"
-        shift
-        shift
+    DBDUMPSDIR="$DBDUMPSDIR/$2"
+    shift
+    shift
 fi
 
 if [ _$1 = _--skip-tables ]; then
-        SKIP_TABLES="$2"
-        shift
-        shift
+    SKIP_TABLES="$2"
+    shift
+    shift
 else
-        SKIP_TABLES=""
+    SKIP_TABLES=""
 fi
 
 MYSQL_CONNECTION_PARAMS="$@"
 
 if [ ! -d $DBDUMPSDIR ]; then
-        mkdir -p $DBDUMPSDIR
-	chmod 700 $DBDUMPSDIR
-	chown root.root $DBDUMPSDIR
+    mkdir -p $DBDUMPSDIR
+    chmod 700 $DBDUMPSDIR
+    chown root.root $DBDUMPSDIR
 fi
 
 
@@ -101,48 +101,63 @@ if [ ! -z "$error" ] ; then
 fi
 for db in $dbs
 do
-	if [ ! -z "$SKIP_TABLES" ] ; then
-		tables=$(echo "show tables" \
-			| mysql --raw --skip-column-names $MYSQL_CONNECTION_PARAMS $db 2>$ERRORFILE \
-			| egrep -v "$SKIP_TABLES"\
-			) || error=true
-		if [ ! -z "$error" ] ; then
-			cat $ERRORFILE | tee --append $ERRORFILELASTRUN
-			exit 1
-		fi
-	else
-		tables=""
-	fi
+    if [ ! -z "$SKIP_TABLES" ] ; then
+        tables=$(echo "show tables" \
+            | mysql --raw --skip-column-names $MYSQL_CONNECTION_PARAMS $db 2>$ERRORFILE \
+            | egrep -v "$SKIP_TABLES"\
+            ) || error=true
+        if [ ! -z "$error" ] ; then
+            cat $ERRORFILE | tee --append $ERRORFILELASTRUN
+            exit 1
+        fi
+    else
+        tables=""
+    fi
 
-        # Don't use pipe to bzip - mysqldump must be fast (locks!)
-        # was: /usr/bin/mysqldump --opt --database $db | /usr/bin/bzip2 -c -9 > $DBDUMPSDIR/mysqldump_$db.sql.bz2
-	#/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db >$TMPFILE 2>&1 || \
-	# neu MKU 2007-12-04
-	# am anfang eines jeden dumps benoetigen wir ein "SET NAMES..."
-	# um fuer einen import auf das richtige char-set zu stellen
-        #/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables >$TMPFILE 2>&1 || \
-	# CON-catenieren!
+    # Don't use pipe to bzip - mysqldump must be fast (locks!)
+    # was: /usr/bin/mysqldump --opt --database $db | /usr/bin/bzip2 -c -9 > $DBDUMPSDIR/mysqldump_$db.sql.bz2
+    #/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db >$TMPFILE 2>&1 || \
+    # neu MKU 2007-12-04
+    # am anfang eines jeden dumps benoetigen wir ein "SET NAMES..."
+    # um fuer einen import auf das richtige char-set zu stellen
+    #/usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables >$TMPFILE 2>&1 || \
+    # CON-catenieren!
+
+    #the database named "mysql" can't be locked
+    #mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
+    CURRENT_OPTS="$MYSQLOPTS"
+    if [ "$db" != "mysql" ] ; then
+        CURRENT_OPTS="$CURRENT_OPTS --lock-tables";
+    fi 
+
+
+    if [ "$db" = "" ] ; then
+        echo "start backup of $db" 
+    else
         echo "start backup of $db.$tables" 
-        echo "SET NAMES 'utf8';" > $TMPFILE
-        /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
-	cat $ERRORFILE | tee --append $ERRORFILELASTRUN
-	# cat $ERRORFILE  | mail -s "Error from $0: DB backup of $db failed" $ERROREMAILTO
-        nice bzip2 -c -9 < $TMPFILE > $DBDUMPSDIR/mysqldump_$db.sql.bz2
+    fi
+    
+    echo "SET NAMES 'utf8';" > $TMPFILE
+    /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $CURRENT_OPTS $db $tables 2>$ERRORFILE 1>>$TMPFILE  || \
+    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
+    # cat $ERRORFILE  | mail -s "Error from $0: DB backup of $db failed" $ERROREMAILTO
+    nice bzip2 -c -9 < $TMPFILE > $DBDUMPSDIR/mysqldump_$db.sql.bz2
 done
 
 if [ $TOTAL -eq 1 ]; then
-        # backup all databases for total recovery
-        # Don't use pipe to bzip - mysqldump must be fast (locks!)
-        # was: /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS --opt --all-databases | bzip2 -c -9 > $DBDUMPSDIR/mysqldump_all_databases.sql.bz2
-	# alt MKU 2007-12-04
-        # /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases >$TMPFILE 2>&1 || \
-	# neu
-	echo "start backup of all databases" 
-	echo "SET NAMES 'utf8';" > $TMPFILE
-        /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases  2>$ERRORFILE >>$TMPFILE || \
-	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
-	    #cat $ERRORFILE  | mail -s "Error from $0: DB backup of ALL failed" $ERROREMAILTO
-        cat $TMPFILE | bzip2 -c -9 > $DBDUMPSDIR/mysqldump_all_databases.sql.bz2
+    # backup all databases for total recovery
+    # Don't use pipe to bzip - mysqldump must be fast (locks!)
+    # was: /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS --opt --all-databases | bzip2 -c -9 > $DBDUMPSDIR/mysqldump_all_databases.sql.bz2
+    # alt MKU 2007-12-04
+    # /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases >$TMPFILE 2>&1 || \
+    # neu
+    echo "start backup of all databases" 
+    echo "SET NAMES 'utf8';" > $TMPFILE
+    /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases  2>$ERRORFILE >>$TMPFILE || \
+        cat $ERRORFILE | tee --append $ERRORFILELASTRUN
+
+    #cat $ERRORFILE  | mail -s "Error from $0: DB backup of ALL failed" $ERROREMAILTO
+    cat $TMPFILE | bzip2 -c -9 > $DBDUMPSDIR/mysqldump_all_databases.sql.bz2
 fi
 
 rm $TMPFILE

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -146,7 +146,7 @@ if [ $TOTAL -eq 1 ]; then
         # /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases >$TMPFILE 2>&1 || \
 	# neu
         echo "start backup of all databases" 
-	   echo "SET NAMES 'utf8';" > $TMPFILE
+	    echo "SET NAMES 'utf8';" > $TMPFILE
         /usr/bin/mysqldump $MYSQL_CONNECTION_PARAMS $MYSQLOPTS --all-databases  2>$ERRORFILE >>$TMPFILE || \
 	    cat $ERRORFILE | tee --append $ERRORFILELASTRUN
 	    #cat $ERRORFILE  | mail -s "Error from $0: DB backup of ALL failed" $ERROREMAILTO

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -126,7 +126,7 @@ do
    #the database named "mysql" can't be locked
    # mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
     CURRENT_OPTS = "$MYSQLOPTS"
-    if[ "$db" -ne "mysql" ]then:
+    if[ "$db" -ne "mysql" ] ; then
         CURRENT_OPTS = "$CURRENT_OPTS --lock-tables";
     fi 
 

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -21,7 +21,7 @@
 # Oder so ähnlich. (vgl. http://dev.mysql.com/doc/refman/4.1/en/innodb-tuning.html)
 #
 
-set -x
+#set -x
 
 
 DBDUMPSDIR=/var/dbdumps

--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -126,7 +126,7 @@ do
    #the database named "mysql" can't be locked
    # mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
     CURRENT_OPTS = "$MYSQLOPTS"
-    if[ "$db" -ne "mysql" ] ; then
+    if [ "$db" -ne "mysql" ] ; then
         CURRENT_OPTS = "$CURRENT_OPTS --lock-tables";
     fi 
 

--- a/loop.sh
+++ b/loop.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env(){
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'MYSQL_ENV_MYSQL_ROOT_PASSWORD'
+
 set -x
 
 echo "sleeping $BACKUP_FIRSTDELAY seconds before first backup"

--- a/loop.sh
+++ b/loop.sh
@@ -24,8 +24,6 @@ file_env(){
 
 file_env 'MYSQL_ENV_MYSQL_ROOT_PASSWORD'
 
-set -x
-
 echo "sleeping $BACKUP_FIRSTDELAY seconds before first backup"
 sleep $BACKUP_FIRSTDELAY
 
@@ -38,6 +36,7 @@ while true ; do
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
         MYSQL_CONNECTION_PARAMS="--host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD"
     fi
+    echo "start backup"
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS
 
 

--- a/loop.sh
+++ b/loop.sh
@@ -45,7 +45,7 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        MYSQL_CONNECTION_PARAMS="--host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_PASSWORD"
+        MYSQL_CONNECTION_PARAMS="--defaults-extra-file=<(printf "[client]\nuser = %s\npassword = %s\nhost = %s" "$MYSQL_USER" "$MYSQL_PASSWORD" "$MYSQL_HOST")"
     fi
     echo "start backup"
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS

--- a/loop.sh
+++ b/loop.sh
@@ -45,7 +45,15 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        MYSQL_CONNECTION_PARAMS="--defaults-extra-file=<(printf \"[client]\nuser = %s\npassword = %s\nhost = %s\" \"$MYSQL_USER\" \"$MYSQL_PASSWORD\" \"$MYSQL_HOST\")"
+        echo << EOF > /tmp/my.cnf
+[client]
+user = $MYSQL_USER
+password = $MYSQL_PASSWORD
+host = $MYSQL_HOST
+EOF
+        cat /tmp/my.cnf
+
+        MYSQL_CONNECTION_PARAMS="--defaults-extra-file=/tmp/my.cnf"
     fi
     echo "start backup"
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS

--- a/loop.sh
+++ b/loop.sh
@@ -1,28 +1,39 @@
 #!/bin/bash
 
+set -x
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
 #  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 file_env(){
-	local var="$1"
-	local fileVar="${var}_FILE"
-	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
-		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
-		exit 1
-	fi
-	local val="$def"
-	if [ "${!var:-}" ]; then
-		val="${!var}"
-	elif [ "${!fileVar:-}" ]; then
-		val="$(< "${!fileVar}")"
-	fi
-	export "$var"="$val"
-	unset "$fileVar"
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+    export "$var"="$val"
+    unset "$fileVar"
 }
 
-file_env 'MYSQL_ENV_MYSQL_ROOT_PASSWORD'
+file_env 'MYSQL_PASSWORD'
+file_env 'MYSQLDUMP_ADD_OPTS'
+file_env 'MYSQL_CONNECTION_PARAMS'
+file_env 'MYSQL_HOST'
+file_env 'MYSQL_USER'
+
+if [ -z "$MYSQL_PASSWORD" ] ; then
+    MYSQL_PASSWORD="$MYSQL_ENV_MYSQL_ROOT_PASSWORD"
+fi
+
 
 echo "sleeping $BACKUP_FIRSTDELAY seconds before first backup"
 sleep $BACKUP_FIRSTDELAY
@@ -34,7 +45,7 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        MYSQL_CONNECTION_PARAMS="--host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_ENV_MYSQL_ROOT_PASSWORD"
+        MYSQL_CONNECTION_PARAMS="--host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_PASSWORD"
     fi
     echo "start backup"
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS

--- a/loop.sh
+++ b/loop.sh
@@ -45,7 +45,7 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        MYSQL_CONNECTION_PARAMS="--defaults-extra-file=<(printf "[client]\nuser = %s\npassword = %s\nhost = %s" "$MYSQL_USER" "$MYSQL_PASSWORD" "$MYSQL_HOST")"
+        MYSQL_CONNECTION_PARAMS="--defaults-extra-file=<(printf \"[client]\nuser = %s\npassword = %s\nhost = %s\" \"$MYSQL_USER\" \"$MYSQL_PASSWORD\" \"$MYSQL_HOST\")"
     fi
     echo "start backup"
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS

--- a/loop.sh
+++ b/loop.sh
@@ -45,7 +45,7 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        echo << EOF > /tmp/my.cnf
+        cat << EOF > /tmp/my.cnf
 [client]
 user = $MYSQL_USER
 password = $MYSQL_PASSWORD

--- a/loop.sh
+++ b/loop.sh
@@ -45,15 +45,16 @@ while true ; do
 
 
     if [ -z "$MYSQL_CONNECTION_PARAMS" ] ; then
-        cat << EOF > /tmp/my.cnf
+        cat << EOF > ~/.my.cnf
 [client]
 user = $MYSQL_USER
 password = $MYSQL_PASSWORD
 host = $MYSQL_HOST
 EOF
-        cat /tmp/my.cnf
+        chmod 0600 ~/.my.cnf
+        cat ~/.my.cnf
 
-        MYSQL_CONNECTION_PARAMS="--defaults-extra-file=/tmp/my.cnf"
+        MYSQL_CONNECTION_PARAMS=""
     fi
     echo "start backup"
     ./backup-all-mysql.sh "$@" $MYSQL_CONNECTION_PARAMS

--- a/loop.sh
+++ b/loop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+# set -x
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'

--- a/loop.sh
+++ b/loop.sh
@@ -52,7 +52,7 @@ password = $MYSQL_PASSWORD
 host = $MYSQL_HOST
 EOF
         chmod 0600 ~/.my.cnf
-        cat ~/.my.cnf
+        # cat ~/.my.cnf
 
         MYSQL_CONNECTION_PARAMS=""
     fi

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Regular backup an DB found in the mysql linked as "mysql" to the voloume `/var/d
 
 You have to:
 
-* run the container `dsteinkopf/backup-all-mysql``
+* run the container `dsteinkopf/backup-all-mysql`
 * create a link called `mysql` to you db to be backed up.
 * Create a volume called `/var/dbdumps`.
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+
 Regular backup an DB found in the mysql linked as "mysql" to the voloume `/var/dbdumps`.
 
 ### Setup
@@ -8,7 +9,7 @@ You have to:
 * create a link called `mysql` to you db to be backed up.
 * Create a volume called `/var/dbdumps`.
 
-### Envorionment
+### Environment
 
 * Interval may be set via environment `BACKUP_INTERVAL` (in seconds).
 * Use `BACKUP_FIRSTDELAY` to delay the very first backup to be done by n seconds. The idea behind this is to prevent existing backups to be overwritten in case of problems. So you can manually kill everything an try again within this delay.
@@ -16,7 +17,14 @@ You have to:
 * MYSQL_CONNECTION_PARAMS (default = ""): More mysql option to add to any mysql command (incl. mysqldump)
 * MYSQL_HOST (default = "mysql"): Hostname (or IP) of mysql database.
 * MYSQL_USER (default = "root"): Username to connect to mysql database.
+* MYSQL_PASSWORD ( use MYSQL_ENV_MYSQL_ROOT_PASSWORD if available ): The password to connect to mysql .
 
+**MYSQLDUMP_ADD_OPTS**, **MYSQL_CONNECTION_PARAMS**, **MYSQL_HOST**,  **MYSQL_USER** ,  **MYSQL_PASSWORD**, can be used with suffix `_FILE`, if stored in a file .
+This is usefull for [docker secrets](https://docs.docker.com/engine/swarm/secrets/) (only available for swarm mode), or to hide sensitive data in general ( like **MYSQL_PASSWORD** ) . 
+
+Example :
+`MYSQL_PASSWORD_FILE=/run/secrets/mysql-root`
+Will read the file `/run/secrets/mysql-root`, and copy the content in the env var `MYSQL_PASSWORD`
 
 ### Monitoring
 
@@ -31,7 +39,7 @@ So to monitor correct backup you should
 
 In docker-compose.yml:
 
-```
+```yml
 mysql-backup:
 
   image: dsteinkopf/backup-all-mysql:latest
@@ -45,6 +53,38 @@ mysql-backup:
     - /opt/dockervolumes/wordpress/mysql-backup:/var/dbdumps
     - /etc/localtime:/etc/localtime
     - /etc/timezone:/etc/timezone
+```
+In docker-compose.yml, for swarm, with secrets ( secrets is already setup )  :
+```yml
+version: '3.2'
+
+services:
+  backup:
+    image: dsteinkopf/backup-all-mysql:latest
+    environment:
+      - BACKUP_INTERVAL=21600 #6h
+      - BACKUP_FIRSTDELAY=3600
+      - MYSQL_HOST=mariadb
+      - MYSQL_ENV_MYSQL_ROOT_PASSWORD_FILE=/run/secrets/mysql-pwd
+    restart: always
+    volumes:
+      - /opt/dockervolumes/wordpress/mysql-backup:/var/dbdumps
+      - /etc/localtime:/etc/localtime
+      - /etc/timezone:/etc/timezone
+    secrets:
+      - mysql-pwd
+      
+  mariadb:
+    image: mariadb:latest
+    secrets:
+      - mysql-pwd
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mysql-pwd
+
+secrets:
+  mysql-pwd:
+    external: true
 ```
 
 -> for example found in [my Zabbix Setup](https://nerdblog.steinkopf.net/2017/01/zabbix-monitoring-leicht-aufgesetzt/) (German language)


### PR DESCRIPTION
When creating a backup of the "mysql" database, mysql generate a warning .

So I remove the --lock-table for the table mysql . It seems to remove the warning ( warning = something in errorslastrun.log ) . 

Maybe it's just a configuration problem . Else, this seems to solve the problem