### PR TITLE
Add --hex-blob

### DIFF
--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -48,7 +48,7 @@ trap aterror EXIT # unset below on normal script end
 # 2. alles bis aus --extended-insert (fuer zeilenweiseinserts) wieder einschalten
 #  somit ergibt sich:
 
-MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --quick --default-character-set=utf8 --routines"
+MYSQLOPTS=" --skip-opt --add-drop-table --add-locks --create-options --set-charset --disable-keys --quick --default-character-set=utf8 --routines --hex-blob"
 if [ ! -z "$MYSQL_CONNECTION_PARAMS" ] ; then
     MYSQLOPTS="$MYSQLOPTS $MYSQLDUMP_ADD_OPTS"
 fi


### PR DESCRIPTION
As I already said .

binary fields "can" ( not always it seems ) break the use of the .sql . 

Maybe related to the binary ( because they are virus fingerprint, so maybe the anti-virus lock it ), or to the lengh ... But --hex-blob can resolve the error .

And In my opinion --hex-blob can't do bad things, but can save your backup :P 