### PR TITLE
move --lock-tables before other opts

### DIFF
--- a/backup-all-mysql.sh
+++ b/backup-all-mysql.sh
@@ -127,7 +127,7 @@ do
     #mysqldump: Got error: 1556: You can't use locks with log tables when using LOCK TABLES
     CURRENT_OPTS="$MYSQLOPTS"
     if [ "$db" != "mysql" ] ; then
-        CURRENT_OPTS="$CURRENT_OPTS --lock-tables";
+        CURRENT_OPTS="--lock-tables $CURRENT_OPTS";
     fi 
 
 


### PR DESCRIPTION
`--skip-lock-tables` need to be adds after `--lock-tables`, so reverte `--lock-tables` in front of the other other arguments

fixes #13